### PR TITLE
Removing .map comment in popper.js. Django 4 throws error for the missing file

### DIFF
--- a/admin_volt/static/admin_volt/assets/vendor/@popperjs/core/dist/cjs/popper-base.js
+++ b/admin_volt/static/admin_volt/assets/vendor/@popperjs/core/dist/cjs/popper-base.js
@@ -1066,4 +1066,3 @@ var createPopper = /*#__PURE__*/popperGenerator(); // eslint-disable-next-line i
 exports.createPopper = createPopper;
 exports.detectOverflow = detectOverflow;
 exports.popperGenerator = popperGenerator;
-//# sourceMappingURL=popper-base.js.map

--- a/admin_volt/static/admin_volt/assets/vendor/@popperjs/core/dist/cjs/popper-lite.js
+++ b/admin_volt/static/admin_volt/assets/vendor/@popperjs/core/dist/cjs/popper-lite.js
@@ -1375,4 +1375,4 @@ exports.createPopper = createPopper;
 exports.defaultModifiers = defaultModifiers;
 exports.detectOverflow = detectOverflow;
 exports.popperGenerator = popperGenerator;
-//# sourceMappingURL=popper-lite.js.map
+

--- a/admin_volt/static/admin_volt/assets/vendor/@popperjs/core/dist/cjs/popper.js
+++ b/admin_volt/static/admin_volt/assets/vendor/@popperjs/core/dist/cjs/popper.js
@@ -1924,4 +1924,3 @@ exports.offset = offset$1;
 exports.popperGenerator = popperGenerator;
 exports.popperOffsets = popperOffsets$1;
 exports.preventOverflow = preventOverflow$1;
-//# sourceMappingURL=popper.js.map


### PR DESCRIPTION
Removing .map comment in popper.js. Django 4 throws error for the missing file