### PR TITLE
.map comment errors

### DIFF
--- a/admin_volt/static/admin_volt/assets/vendor/simplebar/dist/simplebar-core.esm.js
+++ b/admin_volt/static/admin_volt/assets/vendor/simplebar/dist/simplebar-core.esm.js
@@ -886,4 +886,3 @@ SimpleBar.defaultOptions = {
 SimpleBar.instances = new WeakMap();
 
 export default SimpleBar;
-//# sourceMappingURL=simplebar-core.esm.js.map

--- a/admin_volt/static/admin_volt/assets/vendor/simplebar/dist/simplebar.esm.js
+++ b/admin_volt/static/admin_volt/assets/vendor/simplebar/dist/simplebar.esm.js
@@ -991,4 +991,3 @@ if (canUseDOM) {
 }
 
 export default SimpleBar;
-//# sourceMappingURL=simplebar.esm.js.map


### PR DESCRIPTION
one more file containing the comment throwing error on Django 4. sorry for the second request. 